### PR TITLE
SPM-4103 Java 8 downward compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,3 +86,6 @@ wrapper {
     gradleVersion = '6.0'
     distributionType = 'ALL'
 }
+
+// keep Java 8 downward compatibility of the generated artifact
+targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
I wonder if this is an option for you, @james-bryant.

I intend to use the plugin in a Java-8-only environment.
Currently, all builds that use it fail, like this:
```
Caused by: java.lang.UnsupportedClassVersionError: aspectj/AspectJPlugin has been compiled by a more recent version of the Java Runtime (class file version 57.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

